### PR TITLE
feat(deeplink): add calldata URL support and extend QR parsing

### DIFF
--- a/src/deeplink/index.test.ts
+++ b/src/deeplink/index.test.ts
@@ -5,62 +5,102 @@ const testCases = [
     input:
       "https://app.citizenwallet.xyz/#/?alias=app&receiveParams=H4sIAO8gHGUA_7NPTEkpSi0utjWocHG0TDU2dDM0N3MzdTKxtEwydjIysEg0MnBLNTQD8hIdDQydHI3M1BJzMhOLbRMLCgC_bpezPQAAAA==",
     expectedFormat: QRFormat.receiveUrl,
-    expectedData: ["0xDA9e31F176F5B499b3B208a20Fe169b3aA01BA26", null, null],
+    expectedData: [
+      "0xDA9e31F176F5B499b3B208a20Fe169b3aA01BA26",
+      null,
+      null,
+      "app",
+    ],
   },
   {
     input:
       "https://app.citizenwallet.xyz/#/?alias=app&receiveParams=H4sIABYhHGUA_w3MQQqAIBAAwN94jF0ty8MSSviPDZcIsiQLen4e5zIzp3RLrQTf4p0YjDjaOITeudUEDRNriIK2iT1g8NoqPnauxKUoztd7PoQdgMpt4U3oBzYQnutSAAAA",
     expectedFormat: QRFormat.receiveUrl,
-    expectedData: ["0xDA9e31F176F5B499b3B208a20Fe169b3aA01BA26", "1.00", null],
+    expectedData: [
+      "0xDA9e31F176F5B499b3B208a20Fe169b3aA01BA26",
+      "1.00",
+      null,
+      "app",
+    ],
   },
   {
     input:
       "https://app.citizenwallet.xyz/#/?alias=app&voucher=H4sIAOQjHGUA_0WQ22rDMAyG38XXCchWfFDeRgebhbZbSELZKH33Od3Gbmws9Evf54fT7Ws9Ptz8cLqsb3Vzs-O6jz6UUY_NDb_llTe-7Wfbcu8tVSMZMlVFDUlIARkM25RbK5jEPf-CR_08zkCOmVAkiYlB8DEwc21Zp8mslsZqFENoqWUpMWG1bFJIBapaMOsgF2t90P4C_nn-Q9nlWt_djGFw_epn9yiDW93sB7fz9UQwyJQYGvqUoAIF7TuzTcghhA5eofhsuWN0Ou99Y08QRTlDgO55Ot1Y-yRfkRJFJaEkGHPARqIwCVUuBXNNhRqUbERaEmhSsDilXmnIWV6_s9iJJD1rAqMnpnHyDUeKPI1oUdkLYG6n-b1u-_Jx-j2_ASd26ZKxAQAA&params=H4sIAOQjHGUA_wXBMQqAIBQA0Ks4OYaaficHUbtA1P41o6BSrKDj9x4eO94Ga6WpZXxKM-zTKqKSbrV8gABR-pyClgmYYAss0VtQQupe0AvPbObypi03spZGWMfJNHr3A51CYNJWAAAA&alias=app",
     expectedFormat: QRFormat.voucher,
-    expectedData: ["", null, null],
+    expectedData: ["", null, null, null],
   },
   {
     input: "0xDA9e31F176F5B499b3B208a20Fe169b3aA01BA26",
     expectedFormat: QRFormat.address,
-    expectedData: ["0xDA9e31F176F5B499b3B208a20Fe169b3aA01BA26", null, null],
+    expectedData: [
+      "0xDA9e31F176F5B499b3B208a20Fe169b3aA01BA26",
+      null,
+      null,
+      null,
+    ],
   },
   {
     input: "ethereum:0xDA9e31F176F5B499b3B208a20Fe169b3aA01BA26",
     expectedFormat: QRFormat.eip681,
-    expectedData: ["0xDA9e31F176F5B499b3B208a20Fe169b3aA01BA26", null, null],
+    expectedData: [
+      "0xDA9e31F176F5B499b3B208a20Fe169b3aA01BA26",
+      null,
+      null,
+      null,
+    ],
   },
   {
     input:
       "ethereum:0xDA9e31F176F5B499b3B208a20Fe169b3aA01BA26?value=0.1&gas=0.1&gasPrice=0.1&data=0x0",
     expectedFormat: QRFormat.eip681,
-    expectedData: ["0xDA9e31F176F5B499b3B208a20Fe169b3aA01BA26", "0.1", null],
+    expectedData: [
+      "0xDA9e31F176F5B499b3B208a20Fe169b3aA01BA26",
+      "0.1",
+      null,
+      null,
+    ],
   },
   {
     input:
       "ethereum:0x89205a3a3b2a69de6dbf7f01ed13b2108b2c43e7/transfer?address=0xDA9e31F176F5B499b3B208a20Fe169b3aA01BA26&uint256=1",
     expectedFormat: QRFormat.eip681Transfer,
-    expectedData: ["0xDA9e31F176F5B499b3B208a20Fe169b3aA01BA26", "1", null],
+    expectedData: [
+      "0xDA9e31F176F5B499b3B208a20Fe169b3aA01BA26",
+      "1",
+      null,
+      null,
+    ],
   },
   {
     input: "",
     expectedFormat: QRFormat.unsupported,
-    expectedData: ["", null, null],
+    expectedData: ["", null, null, null],
   },
   {
     input: "DA9e31F176F5B499b3B208a20Fe169b3aA01BA26",
     expectedFormat: QRFormat.unsupported,
-    expectedData: ["", null, null],
+    expectedData: ["", null, null, null],
   },
   {
     input:
       "ethereum:0x845598Da418890a674cbaBA26b70807aF0c61dFE@8453/transfer?address=0x6C8bdE31530Ca3382150Fb18e17D8f920CcF86BE",
     expectedFormat: QRFormat.eip681Transfer,
-    expectedData: ["0x6C8bdE31530Ca3382150Fb18e17D8f920CcF86BE", null, null],
+    expectedData: [
+      "0x6C8bdE31530Ca3382150Fb18e17D8f920CcF86BE",
+      null,
+      null,
+      null,
+    ],
   },
   {
     input: "ethereum:0x6C8bdE31530Ca3382150Fb18e17D8f920CcF86BE@8453",
     expectedFormat: QRFormat.eip681,
-    expectedData: ["0x6C8bdE31530Ca3382150Fb18e17D8f920CcF86BE", null, null],
+    expectedData: [
+      "0x6C8bdE31530Ca3382150Fb18e17D8f920CcF86BE",
+      null,
+      null,
+      null,
+    ],
   },
   {
     input:
@@ -70,25 +110,31 @@ const testCases = [
       "0x6C8bdE31530Ca3382150Fb18e17D8f920CcF86BE",
       "10.50",
       "test",
+      "wallet.pay.brussels",
     ],
   },
   {
     input:
       "http://example.com/?sendto=0x6C8bdE31530Ca3382150Fb18e17D8f920CcF86BE@wallet.pay.brussels&amount=10.50",
     expectedFormat: QRFormat.sendtoUrl,
-    expectedData: ["0x6C8bdE31530Ca3382150Fb18e17D8f920CcF86BE", "10.50", null],
+    expectedData: [
+      "0x6C8bdE31530Ca3382150Fb18e17D8f920CcF86BE",
+      "10.50",
+      null,
+      "wallet.pay.brussels",
+    ],
   },
   {
     input:
       "https://example.com/?sendto=xavier@wallet.pay.brussels&amount=10.50",
     expectedFormat: QRFormat.sendtoUrl,
-    expectedData: ["xavier", "10.50", null],
+    expectedData: ["xavier", "10.50", null, "wallet.pay.brussels"],
   },
   {
     input:
       "https://live.citizenwallet.xyz/wallet.pay.brussels/fridge/pay?sendto=fridge@wallet.commonshub.brussels&description=Drinks&amount=3.00",
     expectedFormat: QRFormat.sendtoUrl,
-    expectedData: ["fridge", "3.00", "Drinks"],
+    expectedData: ["fridge", "3.00", "Drinks", "wallet.commonshub.brussels"],
   },
   {
     input:
@@ -98,6 +144,7 @@ const testCases = [
       "0x6C8bdE31530Ca3382150Fb18e17D8f920CcF86BE",
       "10.50",
       "test",
+      "wallet.pay.brussels",
     ],
   },
   {
@@ -108,6 +155,7 @@ const testCases = [
       "0x6C8bdE31530Ca3382150Fb18e17D8f920CcF86BE",
       "10.50",
       "test",
+      "wallet.pay.brussels",
     ],
   },
   {
@@ -118,6 +166,7 @@ const testCases = [
       "0x6C8bdE31530Ca3382150Fb18e17D8f920CcF86BE",
       "10.50",
       "test",
+      "wallet.pay.brussels",
     ],
   },
   {
@@ -128,6 +177,7 @@ const testCases = [
       "0x6C8bdE31530Ca3382150Fb18e17D8f920CcF86BE",
       "10.50",
       "test",
+      "wallet.pay.brussels",
     ],
   },
   {
@@ -138,6 +188,7 @@ const testCases = [
       "0x6C8bdE31530Ca3382150Fb18e17D8f920CcF86BE",
       "10.50",
       "test",
+      "wallet.pay.brussels",
     ],
   },
 ];
@@ -153,9 +204,10 @@ describe("parseQRFormat", () => {
 
 describe("parseQRCode", () => {
   test.each(testCases)(
-    'should parse "$input" as $expected',
+    'should parse "$input" as "$expectedData"',
     ({ input, expectedData }) => {
-      expect(parseQRCode(input)).toEqual(expectedData);
+      const result = parseQRCode(input);
+      expect(result).toEqual(expectedData);
     }
   );
 });

--- a/src/deeplink/index.ts
+++ b/src/deeplink/index.ts
@@ -82,6 +82,7 @@ export const parseQRFormat = (raw: string): QRFormat => {
  * - [0] address: The recipient's address or identifier (e.g., Ethereum address, username)
  * - [1] value: The transfer amount or value (can be null if not specified)
  * - [2] description: Additional message or description for the transfer (can be null if not specified)
+ * - [3] alias/ calldata
  */
 type ParseQRData = [string, string | null, string | null, string | null];
 
@@ -122,8 +123,10 @@ function parseReceiveLink(raw: string): ParseQRData {
 
   const address = params.get("address");
   const amount = params.get("amount");
+  const description = params.get("description");
+  const alias = params.get("alias");
 
-  return [address || "", amount, null, null];
+  return [address || "", amount, description, alias];
 }
 
 function parseSendtoUrl(raw: string): ParseQRData {
@@ -149,7 +152,7 @@ function parseSendtoUrl(raw: string): ParseQRData {
   const [address, alias] = sendToParam.split("@");
 
   // Return parsed data
-  return [address, amountParam, descriptionParam, null];
+  return [address, amountParam, descriptionParam, alias];
 }
 
 function parseCalldataUrl(raw: string): ParseQRData {


### PR DESCRIPTION
- Add new QRFormat.calldataUrl for handling calldata URLs
- Extend ParseQRData type to 4-tuple [address, value, description, alias/calldata]
- Add parseCalldataUrl function for parsing calldata URLs
- Update all existing parsers to return 4-tuple format
- Update test cases to match new ParseQRData structure

This enables parsing of URLs containing calldata parameters for smart contract interactions.